### PR TITLE
MR 8: pass scroll id in the request body in clear scroll request

### DIFF
--- a/src/Concerns/ExecutesQueries.php
+++ b/src/Concerns/ExecutesQueries.php
@@ -202,11 +202,26 @@ trait ExecutesQueries
     {
         $scrollId = $scrollId ?? $this->getScrollId();
 
+        if (empty($scrollId)) {
+            return Collection::empty();
+        }
+
+        $parameters = [
+            'body' => [
+                'scroll_id' => $scrollId
+            ],
+        ];
+
+        if (count($ignores = $this->getIgnores())) {
+            $parameters['client'] = [
+                'ignore' => $ignores,
+            ];
+        }
+
         return new Collection(
-            $this->getConnection()->getClient()->clearScroll([
-                'scroll_id' => $scrollId,
-                'client' => ['ignore' => $this->getIgnores()],
-            ])
+            $this->getConnection()
+                ->getClient()
+                ->clearScroll($parameters)
         );
     }
 

--- a/tests/ExecutesQueriesTest.php
+++ b/tests/ExecutesQueriesTest.php
@@ -22,10 +22,8 @@ class ExecutesQueriesTest extends TestCase
         $clientMock->expects($this->once())
             ->method('clearScroll')
             ->with([
-                'scroll_id' => 'abc123456789',
-                'client' => [
-                    'ignore' => []
-                ]])
+                'body' => ['scroll_id' => 'abc123456789']
+            ])
             ->willReturn([]);
 
         $collection = $this->getQueryObjectWithClient($clientMock)->clear('abc123456789');
@@ -40,14 +38,8 @@ class ExecutesQueriesTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $clientMock->expects($this->once())
-            ->method('clearScroll')
-            ->with([
-                'scroll_id' => null,
-                'client' => [
-                    'ignore' => []
-                ]])
-            ->willReturn([]);
+        $clientMock->expects($this->never())
+            ->method('clearScroll');
 
         $collection = $this->getQueryObjectWithClient($clientMock)->clear();
 

--- a/tests/ExecutesQueriesTest.php
+++ b/tests/ExecutesQueriesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Matchory\Elasticsearch\Tests;
+
+use Elasticsearch\Client;
+use Matchory\Elasticsearch\Collection;
+use Matchory\Elasticsearch\Connection;
+use Matchory\Elasticsearch\Query;
+use Matchory\Elasticsearch\Tests\Traits\ESQueryTrait;
+use PHPUnit\Framework\TestCase;
+
+class ExecutesQueriesTest extends TestCase
+{
+    use ESQueryTrait;
+
+    public function testClearWithScrollId()
+    {
+        $clientMock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $clientMock->expects($this->once())
+            ->method('clearScroll')
+            ->with([
+                'scroll_id' => 'abc123456789',
+                'client' => [
+                    'ignore' => []
+                ]])
+            ->willReturn([]);
+
+        $collection = $this->getQueryObjectWithClient($clientMock)->clear('abc123456789');
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEmpty($collection);
+    }
+
+    public function testClearWithoutScrollId()
+    {
+        $clientMock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $clientMock->expects($this->once())
+            ->method('clearScroll')
+            ->with([
+                'scroll_id' => null,
+                'client' => [
+                    'ignore' => []
+                ]])
+            ->willReturn([]);
+
+        $collection = $this->getQueryObjectWithClient($clientMock)->clear();
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertEmpty($collection);
+    }
+
+    protected function getQueryObjectWithClient(Client $client): Query
+    {
+        return (new Query(
+            new Connection(
+                $client
+            )
+        ))
+            ->index($this->index)
+            ->type($this->type)
+            ->take($this->take)
+            ->skip($this->skip);
+    }
+}


### PR DESCRIPTION
Update the request to scroll API, pass the scroll_id in the body request instead of in URL based on notice:

```
A scroll id can be quite large and should be specified as part of the body in 
/src/Elasticsearch/Endpoints/ClearScroll.php on line 36
```

and API documentation: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-scroll.html